### PR TITLE
--no-circular option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,8 @@ struct Args {
     no_tree: bool,
 
     /// Print circular to stdout
-    #[arg(long, default_value = "true")]
-    circular: bool,
+    #[arg(long, default_value = "false")]
+    no_circular: bool,
 
     /// Print warning to stdout
     #[arg(long, default_value = "false")]
@@ -247,17 +247,19 @@ async fn main() {
         None
     };
 
-    let is_circular_empty = circulars.is_empty();
-    println!(
-        "{}",
-        "• Circular Dependencies"
-            .bold()
-            .color(if is_circular_empty { "green" } else { "red" })
-    );
-    if is_circular_empty {
-        println!("🚀 No circular dependencies found.");
-    } else {
-        println!("{}", utils::pretty::pretty_circular(&circulars, "  "));
+    if !args.no_circular {
+        let is_circular_empty = circulars.is_empty();
+        println!(
+            "{}",
+            "• Circular Dependencies"
+                .bold()
+                .color(if is_circular_empty { "green" } else { "red" })
+        );
+        if is_circular_empty {
+            println!("🚀 No circular dependencies found.");
+        } else {
+            println!("{}", utils::pretty::pretty_circular(&circulars, "  "));
+        }
     }
 
     if !args.no_warning {


### PR DESCRIPTION
Parity with dpdm's --no-circular option.

dpdm uses yargs which allows negating values for boolean flags via a `--no-` prefix: http://yargs.js.org/docs/#api-booleankey

I don't think the argv.circular argument was used in main.rs. This should be backwards-compatible since the default behavior is the same